### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -157,7 +157,6 @@ def run_simulation_stream():
     return jsonify({
       "status": "error",
       "message": "An unexpected error occurred",
-      "error": str(e),
       "timestamp": time.time()
     }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/MirkoZETA/FlexNetSim-API/security/code-scanning/4](https://github.com/MirkoZETA/FlexNetSim-API/security/code-scanning/4)

To fix the problem, we should replace the detailed error message returned to the user with a generic error message. The detailed stack trace should be logged on the server for debugging purposes. This ensures that sensitive information is not exposed to external users while still allowing developers to diagnose issues.

- Modify the `run_simulation_stream` function to return a generic error message instead of the exception message.
- Ensure that the stack trace is logged on the server using the existing `logger.exception` call.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
