### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -70,8 +70,7 @@ def run_simulation():
     logger.exception("Unexpected error during simulation:")
     return jsonify({
       "status": "error",
-      "message": "An unexpected error occurred", 
-      "error": str(e)
+      "message": "An unexpected error occurred"
     }), 500
 
 @app.route("/run_simulation_stream", methods=["POST"])
@@ -157,7 +156,6 @@ def run_simulation_stream():
     return jsonify({
       "status": "error",
       "message": "An unexpected error occurred",
-      "error": str(e),
       "timestamp": time.time()
     }), 500
 


### PR DESCRIPTION
Potential fix for [https://github.com/MirkoZETA/FlexNetSim-API/security/code-scanning/3](https://github.com/MirkoZETA/FlexNetSim-API/security/code-scanning/3)

To fix the problem, we need to modify the code to return a generic error message to the user instead of the detailed exception message. The detailed error message should still be logged on the server for debugging purposes. This can be achieved by removing the `error` field from the JSON response and replacing it with a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
